### PR TITLE
docker: initial configuration and demo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs
 
 # Installer logs
 pip-log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# This file is part of Flask-RateLimiter
+# Copyright (C) 2015 CERN.
+#
+# Flask-RateLimiter is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+FROM python:2.7
+ADD . /code
+WORKDIR /code
+RUN pip install -e .[docs,redis]

--- a/examples/simple/app.py
+++ b/examples/simple/app.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-RateLimiter
+# Copyright (C) 2015 CERN.
+#
+# Flask-RateLimiter is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+"""A simple demo application showing Flask-RateLimiter in action.
+
+Usage:
+  $ fig up
+  $ firefox http://0.0.0.0:5000/
+"""
+
+from os import environ
+
+from flask import Flask
+
+from flask_ratelimiter import RateLimiter
+from flask_ratelimiter import ratelimit
+
+app = Flask(__name__)
+app.config['RATELIMITER_BACKEND_OPTIONS'] = {
+    'host': environ.get('REDIS_HOST', 'localhost')}
+ext = RateLimiter(app=app)
+
+
+@app.route('/')
+@ratelimit(3, 1)
+def index():
+    """Home page."""
+    return 'Hello world!  Try to refresh this page several times per second' \
+        ' to see the rate limiter in action.'
+
+
+if __name__ == '__main__':
+    app.run(host="0.0.0.0", debug=True)

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,20 @@
+# This file is part of Flask-RateLimiter
+# Copyright (C) 2015 CERN.
+#
+# Flask-RateLimiter is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+web:
+  build: .
+  command: python examples/simple/app.py
+  ports:
+   - "5000:5000"
+  environment:
+   - REDIS_HOST=redis
+  volumes:
+   - .:/code
+  links:
+   - redis
+redis:
+  image: redis

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-RateLimiter
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Flask-RateLimiter is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -43,7 +43,8 @@ setup(
         'six',
     ],
     extras_require={
-        'docs': ['sphinx'],
+        'docs': ['pep257', 'sphinx'],
+        'redis': ['redis']
     },
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
* Initial release of docker/fig configuration.  E.g. how to run tests
  while developing: `fig build && fig run web python setup.py test`.

* Adds simple demo application showing Flask-RateLimiter in action.
  Type `fig up -d` and `firefox http://0.0.0.0:5000/` to see it running.

* Adds environment variable `REDIS_HOST` that specifies the Redis server
  hostname, so that one could develop, run the tests, and run the demo
  application either directly from the host OS (where Redis usually runs
  on "localhost"; this is the default) or via Docker (where Redis
  usually runs in another container called "redis").

* Adds missing docstrings and improves code kwalitee of touched files
  with respect to PEP-8 and PEP-257.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>