### PR TITLE
limitter: pass current_limit instead of limit

### DIFF
--- a/flask_ratelimiter/__init__.py
+++ b/flask_ratelimiter/__init__.py
@@ -173,7 +173,7 @@ def ratelimit(limit, per=300, send_x_headers=True,
                                                 scope=scope),
                 current_limit, per)
 
-            info = RateLimitInfo(limit=limit,
+            info = RateLimitInfo(limit=current_limit,
                                  per=per,
                                  limit_exceeded=limit_exceeded,
                                  remaining=remaining,


### PR DESCRIPTION
* Addresses issue with `RateLimitInfo` when `limit` is callable. Passing
  `current_limit` instead of `limit` fixes this odd behavior.