### PR TITLE
limiter: added support for custom backends

### DIFF
--- a/flask_ratelimiter/__init__.py
+++ b/flask_ratelimiter/__init__.py
@@ -85,13 +85,17 @@ class RateLimiter(object):
         >>> ext.init_app(app)
     """
 
-    def __init__(self, app=None):
+    def __init__(self, app=None, backend=None):
         """Create extension instance."""
         if app is not None:
-            self.init_app(app)
+            self.init_app(app, backend=backend)
 
-    def init_app(self, app):
-        """Initialize a Flask extension."""
+    def init_app(self, app, backend=None):
+        """Initialize a Flask extension.
+
+        .. versionchanged:: 0.3
+           Added ``backend`` argument with already initialized backend.
+        """
         self.app = app
 
         if not hasattr(app, 'extensions'):
@@ -120,8 +124,10 @@ class RateLimiter(object):
                 return response
 
         options = config['RATELIMITER_BACKEND_OPTIONS']
-        self.backend = RateLimiter.get_backend(config['RATELIMITER_BACKEND'])(
-            **options)
+        if backend is None:
+            backend = RateLimiter.get_backend(config['RATELIMITER_BACKEND'])(
+                **options)
+        self.backend = backend
 
     @staticmethod
     def get_backend(name):

--- a/flask_ratelimiter/backends/simpleredis_backend.py
+++ b/flask_ratelimiter/backends/simpleredis_backend.py
@@ -27,10 +27,12 @@ class SimpleRedisBackend(Backend):
 
     expiration_window = 10
 
-    def __init__(self, **kwargs):
+    def __init__(self, cache=None, **kwargs):
         """Create Redis connetion instance."""
         super(SimpleRedisBackend, self).__init__(**kwargs)
-        self.cache = Redis(**kwargs)
+        if cache is None:
+            cache = Redis(**kwargs)
+        self.cache = cache
 
     def update(self, key_prefix, limit, per):
         """Update database for specific key_prefix.


### PR DESCRIPTION
**Depends on #21, view the HEAD commit to see intentional changes in this PR**

As discussed in #22, we would like to reuse our existing Redis client for the rate limiter to prevent storing the same options twice. In this PR:

- Added support for passing in an initialized backend to `RateLimiter`
- Added support for passing in an initialized cache to `SimpleRedisBackend`
- Added tests

**Notes:**

I have pre-emptively added the "Reviewed-by" to this commit as it was partially reviewed in #22 (missing tests at the time).