### PR TITLE
docs: deprecation warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,11 @@ About
 Flask-RateLimiter is a Flask extension that provides rate limiting
 decorator.
 
+CAVEAT LECTOR
+=============
+
+**Flask-RateLimiter is now deprecated in favour of** `Flask-Limiter <https://github.com/alisaifee/flask-limiter>`_
+
 Installation
 ============
 Flask-RateLimiter is on PyPI so all you need is: ::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,6 @@
 ===================
 .. currentmodule:: flask_ratelimiter
 
-
 .. raw:: html
 
     <p style="height:22px; margin:0 0 0 2em; float:right">
@@ -20,6 +19,10 @@
 
 Flask-RateLimiter is a Flask extension that provides rate limiting
 decorator.
+
+.. admonition:: **CAVEAT LECTOR**
+
+   **Flask-RateLimiter is now deprecated in favour of** `Flask-Limiter <https://github.com/alisaifee/flask-limiter>`_
 
 Contents
 --------


### PR DESCRIPTION
* Warns people that Flask-RateLimiter is now deprecated in favour of
  Flask-Limiter. <https://github.com/alisaifee/flask-limiter>

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>