### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,10 +1,10 @@
 Authors
 -------
 
-Flask-RateLimiter is developed for use in `Invenio <http://invenio-software.org>`_
+Flask-RateLimiter is developed for use in `Invenio <http://inveniosoftware.org>`_
 digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 * Grzegorz Szpura <grzegorz.szpura@cern.ch>
 * Jiri Kuncar <jiri.kuncar@cern.ch>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -38,8 +38,8 @@ Homepage
 Good luck and thanks for choosing Flask-RateLimiter.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     url='http://github.com/inveniosoftware/flask-ratelimiter/',
     license='BSD',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Flask-RateLimiter is an extension for Flask '
                 'that adds support for rate limiting.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
